### PR TITLE
Improved unread conversation colors

### DIFF
--- a/src/inject/inject.css
+++ b/src/inject/inject.css
@@ -69,6 +69,10 @@ body.darkUI ._2v6o, body.darkUI ._1htf, body.darkUI ._3tky {
     transition: color 0.1s ease-in;
 }
 
+body.darkUI ._1ht3 ._1htf, body.darkUI ._1ht3 ._1ht6, body.darkUI ._1ht3 ._1ht7 {
+    color: rgba(255,255,255,0.7) !important;
+}
+
 body.darkUI ._5742 {
     position: relative;
 }


### PR DESCRIPTION
Set the color of the conversation title, preview, and date to be a brighter shade of grey for unread conversations to improve visibility.

Before: 
![image](https://cloud.githubusercontent.com/assets/3806922/10807255/89e2edee-7e42-11e5-8ba8-f2c2f7d388e5.png)

After:
![image](https://cloud.githubusercontent.com/assets/3806922/10807247/6675c75a-7e42-11e5-9fcc-ac99b7e633b1.png)

Thanks, @wadehammes.
